### PR TITLE
Enable mpremote mip install

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,3 +11,7 @@ replace = version = "{new_version}"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2
 [bumpversion:file:src/tomli/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+
+[bumpversion:file:package.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "urls": [
+      ["tomli/__init__.py", "github:BrianPugh/micropython-tomli/src/tomli/__init__.py"],
+      ["tomli/_parser.py", "github:BrianPugh/micropython-tomli/src/tomli/_parser.py"],
+      ["tomli/_re_time.py", "github:BrianPugh/micropython-tomli/src/tomli/_re_time.py"]
+    ],
+    "deps": [
+    ],
+    "version": "2.0.1"
+}


### PR DESCRIPTION
Adding a package.json makes it simpler for other users to install this to a micropython board using mip install

Below sample is from my fork, but the code actually comes from yours.
Once merged installation can be done using:

 `mpremote mip install github:brianpugh/micropython-tomli`

```bash
mpremote mip install github:josverl/micropython-tomli
Install github:josverl/micropython-tomli
Installing github:josverl/micropython-tomli/package.json to /lib
Installing: /lib/tomli/__init__.py
Installing: /lib/tomli/_parser.py
Installing: /lib/tomli/_re_time.py          
Done   
``` 